### PR TITLE
Making package destination configurable

### DIFF
--- a/_build/build.config.sample.php
+++ b/_build/build.config.sample.php
@@ -7,6 +7,7 @@
  */
 define('MODX_BASE_PATH', dirname(dirname(dirname(dirname(__FILE__)))) . '/modx/');
 define('MODX_CORE_PATH', MODX_BASE_PATH . 'core/');
+define('MODX_PACKAGES_PATH',dirname(dirname(__FILE__)).'/_packages/');
 define('MODX_MANAGER_PATH', MODX_BASE_PATH . 'manager/');
 define('MODX_CONNECTORS_PATH', MODX_BASE_PATH . 'connectors/');
 define('MODX_ASSETS_PATH', MODX_BASE_PATH . 'assets/');

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -48,7 +48,7 @@ $modx->setLogTarget('ECHO');
 
 $modx->loadClass('transport.modPackageBuilder','',false, true);
 $builder = new modPackageBuilder($modx);
-$builder->directory = dirname(dirname(__FILE__)).'/_packages/';
+$builder->directory = MODX_PACKAGES_PATH;
 $builder->createPackage(PKG_NAME_LOWER,PKG_VERSION,PKG_RELEASE);
 $builder->registerNamespace(PKG_NAME_LOWER,false,true,'{core_path}components/'.PKG_NAME_LOWER.'/');
 $modx->log(modX::LOG_LEVEL_INFO,'Created Transport Package and Namespace.');


### PR DESCRIPTION
This allows you to decide where the package goes. For example I use
`define('MODX_PACKAGES_PATH',MODX_CORE_PATH .'/packages/');`
