### PR TITLE
Added system settings for default sort params

### DIFF
--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -8,19 +8,39 @@
 $settings = array();
 
 $settings['collections.mgr_date_format'] = $modx->newObject('modSystemSetting');
-$settings['collections.mgr_date_format']->set('key', 'collections.mgr_date_format');
 $settings['collections.mgr_date_format']->fromArray(array(
-    'value' => '%b %d',
-    'xtype' => 'textfield',
-    'namespace' => 'collections',
+	'key'		=> 'collections.mgr_date_format',
+    'value'		=> '%b %d',
+    'xtype'		=> 'textfield',
+    'namespace'	=> 'collections',
+    'area'		=> ''
 ));
 
 $settings['collections.mgr_time_format'] = $modx->newObject('modSystemSetting');
-$settings['collections.mgr_time_format']->set('key', 'collections.mgr_time_format');
 $settings['collections.mgr_time_format']->fromArray(array(
-    'value' => '%H:%M %p',
-    'xtype' => 'textfield',
-    'namespace' => 'collections',
+	'key'		=> 'collections.mgr_time_format',
+    'value'		=> '%H:%M %p',
+    'xtype'		=> 'textfield',
+    'namespace'	=> 'collections',
+    'area'		=> ''
+));
+
+$settings['collections.mgr_default_sort_field'] = $modx->newObject('modSystemSetting');
+$settings['collections.mgr_default_sort_field']->fromArray(array(
+	'key'		=> 'collections.mgr_default_sort_field',
+    'value'		=> 'createdon',
+    'xtype'		=> 'textfield',
+    'namespace'	=> 'collections',
+    'area'		=> ''
+));
+
+$settings['collections.mgr_default_sort_dir'] = $modx->newObject('modSystemSetting');
+$settings['collections.mgr_default_sort_dir']->fromArray(array(
+	'key'		=> 'collections.mgr_default_sort_dir',
+    'value'		=> 'DESC',
+    'xtype'		=> 'textfield',
+    'namespace'	=> 'collections',
+    'area'		=> ''
 ));
 
 return $settings;

--- a/core/components/collections/processors/mgr/resource/getlist.class.php
+++ b/core/components/collections/processors/mgr/resource/getlist.class.php
@@ -18,10 +18,18 @@ class CollectionsResourceGetListProcessor extends modObjectGetListProcessor {
     public $commentsEnabled = false;
 
     public function initialize() {
+        // cannot access $this->modx above, so we hae to set the values from the system settings here
+        $defaultSortField = $this->modx->getOption('collections.mgr_default_sort_field',null,$defaultSortField);
+        $defaultSortDirection = $this->modx->getOption('collections.mgr_default_sort_dir',null,$defaultSortDirection);
+
         $this->editAction = $this->modx->getObject('modAction',array(
             'namespace' => 'core',
             'controller' => 'resource/update',
         ));
+
+        // re-set the sorting properties
+        $this->setProperty('sort', $defaultSortField);
+        $this->setProperty('dir', $defaultSortDirection);
 
         $sortBy = $this->getProperty('sort');
 


### PR DESCRIPTION
It would be nice to be able to specify the default sortfield / sortdir via system settings. I added and tested the changes successfully so far as I'm able to sort the grid by what's entered in the system settings BUT the problem I have is, that now I cannot use the extjs grid sorting in the manager (manual sorting by the little arrow in the grid headers...) anymore^^...probably this change fixes something a little too hard...but I couldn't find the place to specify this in the extjs files (bc I basically suck at it) instead of the getlist processor...I'm sure you have a better solution for that John...

I also updated the lexicons, but make a separate PR for that because it could be used even if this PR is not merged (what I consider very possible due to the kind of breaking nature of it =D)
