### PR TITLE
Updated English and German lexicons

### DIFF
--- a/core/components/collections/lexicon/de/default.inc.php
+++ b/core/components/collections/lexicon/de/default.inc.php
@@ -7,6 +7,16 @@
  */
 $_lang['collections'] = 'Sammlungen';
 
+// Settings lexicons
+$_lang['setting_collections.mgr_date_format'] = 'Grid Datumsformat';
+$_lang['setting_collections.mgr_date_format_desc'] = 'Hier können Platzhalter für strftime() verwendet werden.';
+$_lang['setting_collections.mgr_time_format'] = 'Grid Zeitformat';
+$_lang['setting_collections.mgr_time_format_desc'] = 'Hier können Platzhalter für strftime() verwendet werden.';
+$_lang['setting_collections.mgr_default_sort_field'] = 'Grid Standard Sortierfeld';
+$_lang['setting_collections.mgr_default_sort_field_desc'] = 'Standard ist "createdon"';
+$_lang['setting_collections.mgr_default_sort_dir'] = 'Grid Standard Sortierreihenfolge';
+$_lang['setting_collections.mgr_default_sort_dir_desc'] = 'Standard ist DESC';
+
 // System lexicons
 $_lang['collections.system.type_name'] = 'Sammlung';
 $_lang['collections.system.text_create'] = 'Sammlung erstellen';
@@ -18,16 +28,20 @@ $_lang['collections.system.all'] = 'Alle';
 $_lang['collections.global.search'] = 'Search';
 
 // Children
-$_lang['collections.children'] = 'Kinder';
-$_lang['collections.children.create'] = 'Kind erstellen';
-$_lang['collections.children.update'] = 'Kind aktualisieren';
-$_lang['collections.children.delete'] = 'Kind löschen';
-$_lang['collections.children.delete_confirm'] = 'Sind Sie sicher, dass Sie dieses Kind löschen möchten?';
+$_lang['collections.children'] = 'Unterresourcen';
+$_lang['collections.children.create'] = 'Unterresource erstellen';
+$_lang['collections.children.update'] = 'Unterresource aktualisieren';
+$_lang['collections.children.delete'] = 'Unterresource löschen';
+$_lang['collections.children.delete_confirm'] = 'Sind Sie sicher, dass Sie diese Unterresource löschen möchten?';
 $_lang['collections.children.publish_multiple'] = 'Auswahl veröffentlichen';
 $_lang['collections.children.unpublish_multiple'] = 'Auswahl zurückziehen';
 $_lang['collections.children.delete_multiple'] = 'Auswahl löschen';
-$_lang['collections.children.delete_multiple_confirm'] = 'Sind Sie sicher, das Sie alle ausgewählen Kinder löschen möchten?';
+$_lang['collections.children.delete_multiple_confirm'] = 'Sind Sie sicher, das Sie alle ausgewählen Unterresourcen löschen möchten?';
 $_lang['collections.children.undelete_multiple'] = 'Auswahl wiederherstellen';
-$_lang['collections.children.none'] = 'Diese Resource hat keine Kinder';
-$_lang['collections.children.err_ns_multiple'] = 'Sie müssen mindestens ein Kind auswählen';
+$_lang['collections.children.none'] = 'Diese Resource hat keine Unterresourcen';
+$_lang['collections.children.err_ns_multiple'] = 'Sie müssen mindestens eine Unterresource auswählen';
 $_lang['collections.children.menuindex'] = 'Menü Index';
+
+$_lang['collections.err.parent_ns'] = 'Keine Elternresource definiert.';
+$_lang['collections.err.bad_sort_column'] = 'Der Grid muss nach <strong>[[+column]]</strong> sortiert sein um Drag & Drop Sortierung zu aktivieren.';
+$_lang['collections.err.clear_filter'] = 'Bitte setzen Sie <strong>filter</strong> und <strong>search</strong> zurück um Drag & Drop Sortierung zu aktivieren.';

--- a/core/components/collections/lexicon/en/default.inc.php
+++ b/core/components/collections/lexicon/en/default.inc.php
@@ -7,6 +7,16 @@
  */
 $_lang['collections'] = 'Collections';
 
+// Settings lexicons
+$_lang['setting_collections.mgr_date_format'] = 'Grid date format';
+$_lang['setting_collections.mgr_date_format_desc'] = 'Placeholders from strftime() can be used here.';
+$_lang['setting_collections.mgr_time_format'] = 'Grid time format';
+$_lang['setting_collections.mgr_time_format_desc'] = 'Placeholders from strftime() can be used here.';
+$_lang['setting_collections.mgr_default_sort_field'] = 'Grid default sort field';
+$_lang['setting_collections.mgr_default_sort_field_desc'] = 'Defaults to "createdon"';
+$_lang['setting_collections.mgr_default_sort_dir'] = 'Grid default sort direction';
+$_lang['setting_collections.mgr_default_sort_dir_desc'] = 'Defaults to DESC';
+
 // System lexicons
 $_lang['collections.system.type_name'] = 'Collection';
 $_lang['collections.system.text_create'] = 'Collection';


### PR DESCRIPTION
Small correction in German lexicon as the term "Kind" (which is correct translation for child) is kind of strange to my editors^^ =)

Also added German/English lexicon entries for the system settings (including the new ones)

And added the new drag and drop lexicon strings to the German lexicon.
