### PR TITLE
Ignore "ready" event if update-resource does not exist

### DIFF
--- a/assets/components/collections/js/mgr/extra/hijackclose.js
+++ b/assets/components/collections/js/mgr/extra/hijackclose.js
@@ -1,5 +1,7 @@
 MODx.on("ready",function() {
     var update = Ext.getCmp('modx-page-update-resource');
+    if (!update)
+        return;
     var parentId = update.config.record.parent;
 
     var cancelHandler = function(btn,e) {


### PR DESCRIPTION
This fixes AjaxManager compatibility issue.
Thanks in advance.
