### PR TITLE
Fix wrong version number in build script (prevents update)

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -14,7 +14,7 @@ set_time_limit(0);
 /* define package */
 define('PKG_NAME','Collections');
 define('PKG_NAME_LOWER',strtolower(PKG_NAME));
-define('PKG_VERSION','1.2.0');
+define('PKG_VERSION','1.3.0');
 define('PKG_RELEASE','pl');
 
 /* define sources */


### PR DESCRIPTION
As the package manager still thinks it's version 1.2.0, there is no update possible without uninstalling version 1.2.0.
