### PR TITLE
Hide the unnecessary tree arrow via css

### DIFF
--- a/assets/components/collections/css/mgr.css
+++ b/assets/components/collections/css/mgr.css
@@ -136,4 +136,5 @@
 
 .icon-collectioncontainer .x-tree-elbow-plus {
     background-image: none;
+    cursor: default;
 }


### PR DESCRIPTION
This would fix https://github.com/modxcms/Collections/issues/13 in a bit hacky way, but preserves drag and drop functionality 8)
