### PR TITLE
Fix for grid not rendering

### DIFF
--- a/assets/components/collections/js/mgr/extra/collections.renderers.js
+++ b/assets/components/collections/js/mgr/extra/collections.renderers.js
@@ -36,7 +36,7 @@ Collections.renderer.pagetitleLink = function(value, metaData, record, rowIndex,
 
 Collections.renderer.datetimeTwoLines = function(value, metaData, record, rowIndex, colIndex, store) {
     if (value == 0) return '';
-
+    value = value.replace(/-/g,'/');
     var dateTime = new Date(value);
     var date = dateTime.format(MODx.config['collections.mgr_date_format']);
     var time = dateTime.format(MODx.config['collections.mgr_time_format']);
@@ -46,7 +46,7 @@ Collections.renderer.datetimeTwoLines = function(value, metaData, record, rowInd
 
 Collections.renderer.datetime = function(value, metaData, record, rowIndex, colIndex, store) {
     if (value == 0) return '';
-
+    value = value.replace(/-/g,'/');
     var dateTime = new Date(value);
     dateTime = dateTime.format(MODx.config['collections.mgr_datetime_format']);
 


### PR DESCRIPTION
Fix for grid not rendering on Firefox and IE (latest version) when using _'dateTime'_ and _'dateTimeTwoLines'_ renders. When converting the value in a Date object, FF was returning an "Invalid Date" due to the use of - instead of / as a valid date string across all browsers _(Google Chrome is more permissive on this)_.
