### PR TITLE
Fix # being appended to manager url when clicking a button

### DIFF
--- a/assets/components/collections/js/mgr/extra/collections.renderers.js
+++ b/assets/components/collections/js/mgr/extra/collections.renderers.js
@@ -3,7 +3,7 @@ var pagetitleWithButtons = new Ext.XTemplate('<tpl for="."><div class="collectio
     +'<tpl if="actions">'
     +'<ul class="actions">'
     +'<tpl for="actions">'
-    +'<li><a href="#" class="controlBtn {className}">{text}</a></li>'
+    +'<li><a href="javascript:void(0);" class="controlBtn {className}">{text}</a></li>'
     +'</tpl>'
     +'</ul>'
     +'</tpl>'


### PR DESCRIPTION
The template for the action buttons has a # inside the href attribute of the link which get's appended to the manager URL when a button is clicked (edit for example), when browsing back (via browser back button) the page jumps to the content field and is not scrollable anymore (Chrome), the provided solution fixes this issue.
