### PR TITLE
Fix strict standards error (PHP 5.4+) in resource/getlist processor

### DIFF
--- a/core/components/collections/processors/mgr/resource/getlist.class.php
+++ b/core/components/collections/processors/mgr/resource/getlist.class.php
@@ -166,7 +166,7 @@ class CollectionsResourceGetListProcessor extends modObjectGetListProcessor {
      * @param modResource $object
      * @return array
      */
-    public function prepareRow($object) {
+    public function prepareRow(xPDOObject $object) {
         $resourceArray = parent::prepareRow($object);
 
         $resourceArray['action_edit'] = '?a=resource/update&action=post/update&id='.$resourceArray['id'];


### PR DESCRIPTION
The resources grid/list in a collection cannot be displayed in PHP 5.4+ due to a strict standards error (tested in 2.2.x):

<b>Strict Standards</b>:  Declaration of CollectionsResourceGetListProcessor::prepareRow() should be compatible with modObjectGetListProcessor::prepareRow(xPDOObject $object)

with the provided fix the grid loads again.
