### PR TITLE
Minor fixes

### DIFF
--- a/core/components/collections/elements/snippets/getselections.snippet.php
+++ b/core/components/collections/elements/snippets/getselections.snippet.php
@@ -68,6 +68,7 @@ $properties = $scriptProperties;
 unset($properties['selections']);
 
 $properties['resources'] = $linkedResources;
+$properties['parents'] = '-1';
 
 if ($sortBy == '') {
     $properties['sortby'] = 'FIELD(modResource.id, ' . $linkedResources . ' )';


### PR DESCRIPTION
Most people are used to `ASC` and `DESC` (capitalized) syntax for getResource properties.

When testing it seems leaving the getResources property `$parents` to the default returns unpredictable results. Setting it '-1' forces getResources to use the results of the getSelections query only.
