### PR TITLE
Fix for getResourcesSnippet = pdoResources

### DIFF
--- a/core/components/collections/elements/snippets/getselections.snippet.php
+++ b/core/components/collections/elements/snippets/getselections.snippet.php
@@ -68,7 +68,7 @@ $properties = $scriptProperties;
 unset($properties['selections']);
 
 $properties['resources'] = $linkedResources;
-$properties['parents'] = -1;
+$properties['parents'] = ($properties['getResourcesSnippet'] == 'pdoResources') ? 0 : -1;
 
 if ($sortBy == '') {
     $properties['sortby'] = 'FIELD(modResource.id, ' . $linkedResources . ' )';


### PR DESCRIPTION
Since pdoResources allows to exclude resource trees by prepending - to the resource id, you can't use ``&parents=`-1` `` there.