### PR TITLE
Display the resource id after the pagetitle

### DIFF
--- a/core/components/collections/processors/mgr/extra/getresources.class.php
+++ b/core/components/collections/processors/mgr/extra/getresources.class.php
@@ -103,5 +103,17 @@ class CollectionsExtrasResourceGetListProcessor extends modObjectGetListProcesso
         return $data;
     }
 
+    /**
+     * Prepare the row for iteration
+     * @param xPDOObject $object
+     * @return array
+     */
+    public function prepareRow(xPDOObject $object) {
+        $ta = $object->toArray();
+
+        $ta['pagetitle'] .= ' (' . $ta['id'] . ')';
+        return $ta;
+    }
+
 }
 return 'CollectionsExtrasResourceGetListProcessor';


### PR DESCRIPTION
If multiple resources are named the same it is the only option to pick the right one.

It would be better to make this customizable. The best option would be a tree select as i.e. on http://modx.com/extras/package/pickresource2