### PR TITLE
Color change of the Collection's Resource title

### DIFF
--- a/assets/components/collections/css/mgr.css
+++ b/assets/components/collections/css/mgr.css
@@ -17,13 +17,13 @@
 }
 
 .collections-grid a {
-    color:#485319;
+    color:#556C88;
     line-height:1;
     text-decoration:none;
 }
 
 .collections-grid a:hover {
-    color:#7a8f23;
+    color:#738BA9;
     text-decoration:none;
 }
 


### PR DESCRIPTION
 I found the dark-green not accorded with the default MODX Manager template.
I suggest to change the color of the title with a dark-blue color