### PR TITLE
Fix too long title slipping down

### DIFF
--- a/assets/components/collections/css/mgr.css
+++ b/assets/components/collections/css/mgr.css
@@ -114,6 +114,8 @@
 
 .collections-grid .main-column {
     font-size: 16px;
+    overflow: hidden;
+    white-space: normal;
 }
 
 .collections-grid .main-column.buttons {


### PR DESCRIPTION
Fix #188 // takes care of too long titles slipping down and normalizes the white-space

From:
![image](https://cloud.githubusercontent.com/assets/3798871/13342192/6c9ea7a4-dc3f-11e5-80d2-68be0af34652.png)
To:
![image](https://cloud.githubusercontent.com/assets/3798871/13342195/75d04c92-dc3f-11e5-90e1-06df3cebf1a7.png)

But I found more to fix, should I also commit or open an issue before? 