### PR TITLE
Add overflow ellipse to the main-column

### DIFF
--- a/assets/components/collections/css/mgr.css
+++ b/assets/components/collections/css/mgr.css
@@ -122,7 +122,10 @@
 }
 
 .collections-grid .main-column a {
-    float: left;
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 .collections-grid .collections-title-column ul {
     clear: both;


### PR DESCRIPTION
- Float is not needed since the icon floats.
- The other changes create an ellipse sign in long lines instead of just cut off the overflow.