### PR TITLE
Boolean renderer using basic font awesome icons

### DIFF
--- a/assets/components/collections/js/mgr/extra/collections.renderers.js
+++ b/assets/components/collections/js/mgr/extra/collections.renderers.js
@@ -116,6 +116,10 @@ collections.renderer.image = function(value, metaData, record, rowIndex, colInde
         return '<img src="' + MODx.config.base_url + imgPath + value + '" width="64">';
     }
 };
+collections.renderer.boolean = function(value, metaData, record, rowIndex, colIndex, store) {
+    var iconclass = (value) ? 'icon-check' : 'icon-times';
+    return '<div style="text-align:center;"><i class="icon ' + iconclass + '"></i></div>';
+}
 
 
 // Backwards compatibility
@@ -129,5 +133,6 @@ Collections.renderer = {
     datetimeTwoLines: collections.renderer.datetimeTwoLines,
     datetime: collections.renderer.datetime,
     timestampToDatetime: collections.renderer.timestampToDatetime,
-    image: collections.renderer.image
+    image: collections.renderer.image,
+    boolean: collections.renderer.boolean
 };


### PR DESCRIPTION
## What it does
Adds a renderer to show font awesome icon for boolean values

## Why it's needed
It looks better than a `1` or `0` and helps users more quickly understand the field value.