### PR TITLE
Fixed some markdown glitches

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ Collections is a MODX Revolution Extra that adds a custom `CollectionContainer` 
 
 ![Collections Children Grid](http://modx.com/assets/i/blogs/yj/Collections-Grid-View.png)
 
-####Sub Collections
+#### Sub Collections
 Just like the MODX Resource Tree itself, Collections supports nesting. You can create a Collection within another Collection. Sub Collection Containers will be displayed in the resource tree and their children will be displayed in the grid view.
 
-####Drag n Drop
+#### Drag n Drop
 You can drag n drop Resources into a Collections container and if they don't have children of their own they will be listed in the grid. If they do have children, they'll just remain in the Tree as usual.
 
-###Custom Views
+### Custom Views
 As of version 2.x, Collections supports customizable views. Views are configured in Collections Custom Manager Page (CMP):
 
-![Collections CMP] (http://modx.com/assets/i/blogs/yj/Collections-CMP.png)
-![Collections New View] (http://modx.com/assets/i/blogs/yj/Collections-New-View3.png)
+![Collections CMP](http://modx.com/assets/i/blogs/yj/Collections-CMP.png)
+![Collections New View](http://modx.com/assets/i/blogs/yj/Collections-New-View3.png)
 
 There are specific settings for Collections Resources vs Selections.
 
-###Resources
-The official documentation for Collections can be found here: [http://rtfm.modx.com/extras/revo/collections] (http://rtfm.modx.com/extras/revo/collections)
+### Resources
+The official documentation for Collections can be found on [rtfm.modx.com/extras/revo/collections](https://docs.modx.com/extras/revo/collections)


### PR DESCRIPTION
There are some stricter checks in newer GFM versions, i.e. there has to be a space after a # in a headline.