### PR TITLE
Make sure collections is loaded

### DIFF
--- a/core/components/collections/elements/plugins/collections.plugin.php
+++ b/core/components/collections/elements/plugins/collections.plugin.php
@@ -21,6 +21,8 @@ $collections = $modx->getService(
     )
 );
 
+if (!($collections instanceof Collections)) { return ''; }
+
 $className = 'Collections' . $modx->event->name;
 
 $modx->loadClass('CollectionsPlugin', $collections->getOption('modelPath') . 'collections/events/', true, true);


### PR DESCRIPTION
If something happens to the collections path or folder, the MODX manager won't load.  This adds a check to make sure Collections exists as an object.