### PR TITLE
Added php_renderer to Collections columns grid

### DIFF
--- a/assets/components/collections/js/mgr/widgets/template/column.grid.js
+++ b/assets/components/collections/js/mgr/widgets/template/column.grid.js
@@ -149,6 +149,14 @@ Ext.extend(collections.grid.TemplateColumn,MODx.grid.Grid,{
             ,width: 100
             ,renderer: collections.renderer.qtip
         },{
+            header: _('collections.template.column.php_renderer')
+            ,dataIndex: 'php_renderer'
+            ,sortable: true
+            ,editor: {xtype: 'textfield'}
+            ,hidden: true
+            ,width: 100
+            ,renderer: collections.renderer.qtip
+        },{
             header: _('collections.template.column.position')
             ,dataIndex: 'position'
             ,sortable: true


### PR DESCRIPTION
Was the snippet renderer intentionally kept away from the grid or just forgotten? This patch adds it to the selectable columns.