### PR TITLE
 Forbid generating child resources in the tree for Collections/Selections

### DIFF
--- a/core/components/collections/model/collections/collectioncontainer.class.php
+++ b/core/components/collections/model/collections/collectioncontainer.class.php
@@ -10,6 +10,7 @@ class CollectionContainer extends modResource
 {
     public $showInContextMenu = true;
     public $allowDrop = 1;
+    public $allowChildrenResources = false;
 
     function __construct(xPDO & $xpdo)
     {

--- a/core/components/collections/model/collections/selectioncontainer.class.php
+++ b/core/components/collections/model/collections/selectioncontainer.class.php
@@ -8,6 +8,7 @@ class SelectionContainer extends CollectionContainer
 {
     public $showInContextMenu = true;
     public $allowDrop = 1;
+    public $allowChildrenResources = false;
 
     function __construct(xPDO & $xpdo)
     {


### PR DESCRIPTION
This PR has the following advantages:
- The new Revolution 2.7 plus sign is hidden on the collectionContainer and selectionContainer resource type
- The quick create or create context menu is not shown and bypassing the default template etc. for Collection children is not possible anymore
- The triangle in the tree before a collection would be hidden
