### PR TITLE
 Fix small page titles

### DIFF
--- a/assets/components/collections/js/mgr/widgets/category/collections.panel.selection.js
+++ b/assets/components/collections/js/mgr/widgets/category/collections.panel.selection.js
@@ -8,12 +8,9 @@ Ext.extend(collections.panel.Selection,MODx.panel.Resource,{
     getPageHeader: function(config) {
         config = config || {record:{}};
         return {
-            html: '<h2>'+_('collections.container_new')+'</h2>'
+            html: _('collections.container_new')
             ,id: 'modx-resource-header'
-            ,cls: 'modx-page-header'
-            ,border: false
-            ,forceLayout: true
-            ,anchor: '100%'
+            ,xtype: 'modx-header'
         };
     }
 


### PR DESCRIPTION
To fix issue #273.

Same method as used in
https://github.com/modxcms/revolution/blob/2.x/manager/assets/modext/widgets/resource/modx.panel.resource.js#L449:L451