### PR TITLE
Fix for MODX 3

### DIFF
--- a/_build/resolvers/resolve.updatefromfirst.php
+++ b/_build/resolvers/resolve.updatefromfirst.php
@@ -12,7 +12,7 @@ if ($object->xpdo) {
                 'workspace' => 1,
                 "(SELECT
                         `signature`
-                      FROM {$modx->getTableName('modTransportPackage')} AS `latestPackage`
+                      FROM {$modx->getTableName('transport.modTransportPackage')} AS `latestPackage`
                       WHERE `latestPackage`.`package_name` = `modTransportPackage`.`package_name`
                       ORDER BY
                          `latestPackage`.`version_major` DESC,


### PR DESCRIPTION
To get the table name the class has to be 'qualified'.

There are a lot of other extras that have a similar problem.