### PR TITLE
Fix undefined constant error (php8) and manager breaking error if the service is unavailable

### DIFF
--- a/core/components/collections/controllers/update.class.php
+++ b/core/components/collections/controllers/update.class.php
@@ -220,7 +220,7 @@ class CollectionContainerUpdateManagerController extends ResourceUpdateManagerCo
             ];
 
             if ($column->editor != '') {
-                $editorObj = json_decode($column->editor, to);
+                $editorObj = json_decode($column->editor, true);
                 if ($editorObj == null) {
                     $editorObj = [
                         'xtype' => $column->editor,

--- a/core/components/collections/elements/plugins/Collections.php
+++ b/core/components/collections/elements/plugins/Collections.php
@@ -10,10 +10,13 @@
  * @var \MODX\Revolution\modX $modx
  * @var array $scriptProperties
  */
-$corePath = $modx->getOption('collections.core_path', null, $modx->getOption('core_path', null, MODX_CORE_PATH) . 'components/collections/');
+
+if (!$modx->services->has('collections')) {
+    return;
+}
+
 /** @var Collections\Collections $collections */
 $collections = $modx->services->get('collections');
-
 if (!($collections instanceof Collections\Collections)) return '';
 
 $className = "\\Collections\\Events\\{$modx->event->name}";


### PR DESCRIPTION
- First issue is a typo causing a (handled) error `Undefined constant "to"` on PHP8
- Second issue happens when, for example, you try to set up the repository from git manually and enter the wrong path in the namespace. That causes the service to not be available, and a fatal error occurs that breaks the entire manager. 