### PR TITLE
Fix child_resource_type for new templates

### DIFF
--- a/assets/components/collections/js/mgr/widgets/template/template.panel.js
+++ b/assets/components/collections/js/mgr/widgets/template/template.panel.js
@@ -779,7 +779,7 @@ Ext.extend(collections.panel.Template, MODx.FormPanel,{
                         ,hiddenName: 'child_resource_type'
                         ,allowBlank: false
                         ,editable: false
-                        ,value: (config.record) ? config.record.child_resource_type : 'modDocument'
+                        ,value: (config.record) ? config.record.child_resource_type : 'MODX\Revolution\modDocument'
                     }]
                 }]
             }]


### PR DESCRIPTION
This fixes the issue of creating collection children with the wrong resource type `modDocument` instead of `MODX\Revolution\modDocument`, when the collection uses a new created collection template. Existing and duplicated collection templates are fine. 

The resource type combo box shows modDocument in the templates that create this issue. Templates that do not create the issue are showing Document there.