### PR TITLE
fix: Unable to create a new Collections View

### DIFF
--- a/core/components/collections/src/Utils.php
+++ b/core/components/collections/src/Utils.php
@@ -4,7 +4,9 @@ namespace Collections;
 class Utils {
     public static function explodeAndClean($array, $delimiter = ',', $keepDuplicates = 0)
     {
-        $array = explode($delimiter, $array);     // Explode fields to array
+        if (!is_array($array)) {
+            $array = explode($delimiter, $array);     // Explode fields to array
+        }
         $array = array_map('trim', $array);       // Trim array's values
 
         if ($keepDuplicates == 0) {


### PR DESCRIPTION
Fix https://github.com/modxcms/Collections/issues/349

The method caused an error, because when creating a new collection view, an array is immediately passed as the first argument, and in other cases, a string. Maybe the method should be renamed?