### PR TITLE
Fetch distinct resources

### DIFF
--- a/core/components/collections/processors/mgr/resource/getlist.class.php
+++ b/core/components/collections/processors/mgr/resource/getlist.class.php
@@ -365,7 +365,7 @@ class CollectionsResourceGetListProcessor extends modObjectGetListProcessor
     public function prepareQueryAfterCount(xPDOQuery $c)
     {
 
-        $c->select($this->modx->getSelectColumns('modResource', 'modResource'));
+        $c->select('DISTINCT ' . $this->modx->getSelectColumns('modResource', 'modResource'));
         $c->select(array(
             'has_children' => "EXISTS (SELECT 1 FROM {$this->modx->getTableName('modResource')} r WHERE r.parent = modResource.id)"
         ));


### PR DESCRIPTION
When using the search feature in Tagger on a site using Tagger, the wrong number of resources are returned.

The COUNT query is correct because it already looks at distinct resources, but the data query doesn't. This means it fetches one row per Tagger tag linked to the resource and so the wrong number of results are shown.

In my test case the query should have returned 9 resources. Instead it returned 3 because the first and second resources had 1 tag each, and the third resource 8 tags. With the `LIMIT 10` on results, these 10 rows were all that were retrieved, and there is no pagination because there should only be 9 resources.

This patch fixes the problem and returns distinct rows.