### PR TITLE
Add display of collections in collection grid

### DIFF
--- a/_build/gpm.json
+++ b/_build/gpm.json
@@ -73,6 +73,11 @@
             "namespace": "core"
         },
         {
+            "key": "mgr_show_collections_in_grid",
+            "area": "manager",
+            "value": ""
+        },
+        {
             "key": "renderer_image_path",
             "area": "manager",
             "value": ""

--- a/core/components/collections/lexicon/en/default.inc.php
+++ b/core/components/collections/lexicon/en/default.inc.php
@@ -31,6 +31,8 @@ $_lang['setting_collections.tree_tbar_collection'] = 'Tree Tool Bar - Collection
 $_lang['setting_collections.tree_tbar_collection_desc'] = 'Show "New Collection" button in Tree tool bar';
 $_lang['setting_collections.tree_tbar_selection'] = 'Tree Tool Bar - Selection';
 $_lang['setting_collections.tree_tbar_selection_desc'] = 'Show "New Selection" button in Tree tool bar';
+$_lang['setting_collections.mgr_show_collections_in_grid'] = 'Collection templates displayed in grid';
+$_lang['setting_collections.mgr_show_collections_in_grid_desc'] = 'You can specify Collection templates, separated by commas, that will be displayed inside Collection grid.';
 
 
 // System lexicons

--- a/core/components/collections/src/Events/OnBeforeDocFormSave.php
+++ b/core/components/collections/src/Events/OnBeforeDocFormSave.php
@@ -22,7 +22,11 @@ class OnBeforeDocFormSave extends Event
         }
 
         if ($resource->class_key == CollectionContainer::class) {
-            $resource->set('show_in_tree', 1);
+            if (in_array($resource->get('template'), explode(',', $this->modx->getOption('collections.mgr_show_collections_in_grid')))) {
+                $resource->set('show_in_tree', 0);
+            } else {
+                $resource->set('show_in_tree', 1);
+            }
         }
 
         /** @var modResource $original */

--- a/core/components/collections/src/Processors/Resource/GetList.php
+++ b/core/components/collections/src/Processors/Resource/GetList.php
@@ -365,10 +365,23 @@ class GetList extends GetListProcessor
                 break;
         }
 
-        $c->where([
-            'class_key:!=' => CollectionContainer::class,
-//            "NOT EXISTS (SELECT 1 FROM {$this->modx->getTableName('modResource')} r WHERE r.parent = modResource.id)"
-        ]);
+        $showCollectionsInGrid = explode(',', $this->modx->getOption('collections.mgr_show_collections_in_grid'));
+        if (!empty($showCollectionsInGrid)) {
+            $c->where([
+                'parent' => $parent,
+                'AND:template:IN' => $showCollectionsInGrid,
+                'AND:class_key:=' => CollectionContainer::class,
+            ]);
+            $c->where([
+                'parent' => $parent,
+                'AND:class_key:!=' => CollectionContainer::class,
+            ], xPDOQuery::SQL_OR);
+        } else {
+            $c->where([
+                'class_key:!=' => CollectionContainer::class,
+                // "NOT EXISTS (SELECT 1 FROM {$this->modx->getTableName('modResource')} r WHERE r.parent = modResource.id)"
+            ]);
+        }
 
         foreach ($this->tvColumns as $column) {
             $c->leftJoin(modTemplateVarResource::class, '`TemplateVarResources_' . $column['column'] . '`', '`TemplateVarResources_' . $column['column'] . '`.`contentid` = modResource.id AND `TemplateVarResources_' . $column['column'] . '`.`tmplvarid` = ' . $column['id']);


### PR DESCRIPTION
Added the ability to display collections within a collection, in a grid.

In the system settings, you can specify collection templates, separated by commas, that will be displayed within the grid.

Before
![before](https://github.com/user-attachments/assets/c8d990ce-9213-454d-899b-b875ace9e17c)

After
![after](https://github.com/user-attachments/assets/e9ce9ceb-640d-4dd7-9045-14dd841038fd)

https://github.com/modxcms/Collections/issues/369
https://github.com/modxcms/Collections/issues/250