### PR TITLE
4.1.1 Issue: Language Topic not loaded for ContentTypes

### DIFF
--- a/core/components/collections/src/Processors/Extra/GetContentTypes.php
+++ b/core/components/collections/src/Processors/Extra/GetContentTypes.php
@@ -7,7 +7,7 @@ use MODX\Revolution\Processors\Model\GetListProcessor;
 class GetContentTypes extends GetListProcessor
 {
     public $classKey = modContentType::class;
-    public $languageTopics = ['content_type'];
+    public $languageTopics = ['content_type','collections:default'];
 
     public function afterIteration(array $list)
     {


### PR DESCRIPTION
In collection view setting, for content Types, the value of entry of lexicon topic dont’ appear, only see the index. This beacause don’t load the lexicon topic.
On file core\components\collections\src\Processors\Extra\ GetContentTypes.php at line 10. add collections:default