### PR TITLE
4.1.1 Issue: resource's class_key and icon in GetList.php

### DIFF
--- a/core/components/collections/src/Processors/Resource/GetList.php
+++ b/core/components/collections/src/Processors/Resource/GetList.php
@@ -654,16 +654,18 @@ class GetList extends GetListProcessor
             $iconCls[] = $classKeyIcon;
         }
 
-        switch ($classKey) {
-            case 'weblink':
+        //MABOL, i change only this but error for class_key exist in before line
+		$classKeyNew = strtolower($resourceArray['class_key']);
+        switch ($classKeyNew) {
+            case 'modx\revolution\modweblink':
                 $iconCls[] = $this->iconMap['weblink'];
                 break;
 
-            case 'symlink':
+            case 'modx\revolution\modsymlink':
                 $iconCls[] = $this->iconMap['symlink'];
                 break;
 
-            case 'staticresource':
+            case 'modx\revolution\modstaticresource':
                 $iconCls[] = $this->iconMap['staticresource'];
                 break;
         }


### PR DESCRIPTION
In the **prepareIcons** function, the old nomenclature for class_key (e.g. modResource) is considered and not the new one (e.g. modx\revolution\modResource), both contain "mod", which is removed