### PR TITLE
4.1.1 Issue: nested selection, resourse and open button. Change: open only for resources

### DIFF
--- a/assets/components/collections/js/mgr/widgets/category/collections.grid.resources.js
+++ b/assets/components/collections/js/mgr/widgets/category/collections.grid.resources.js
@@ -356,13 +356,7 @@ Ext.extend(collections.grid.ContainerCollections,MODx.grid.Grid,{
             collectionGet = '&collection=' + collections.template.parent
         }
 
-        var folderGet = '';
-        var query = Ext.urlDecode(location.search.replace('?', ''));
-        if (parseInt(query.folder) > 0) {
-            folderGet = '&folder=' + parseInt(query.folder);
-        }
-
-        return collections.getPageUrl(MODx.request.a, 'id=' + data.id + selection + collectionGet + folderGet);
+        return collections.getPageUrl(MODx.request.a, 'id=' + data.id + selection + collectionGet );
     }
 
     ,createChild: function(btn,e) {

--- a/core/components/collections/src/Processors/Resource/GetList.php
+++ b/core/components/collections/src/Processors/Resource/GetList.php
@@ -539,9 +539,9 @@ class GetList extends GetListProcessor
                         }
                         break;
                     case 'open':
-//                        if ($resourceArray['has_children'] == '1') {
-                        $resourceArray['actions'][] = $this->actions['open'];
-//                        }
+                        if ($resourceArray['class_key'] != 'Collections\Model\CollectionContainer' && $resourceArray['class_key'] != 'Collections\Model\SelectionContainer') {
+                        							$resourceArray['actions'][] = $this->actions['open'];
+						}
                         break;
                     case 'edit':
                         if ($this->permissions['edit_document']) {


### PR DESCRIPTION
If you create collection and then selection inside, when click open button for selection and add a second selection , is not possible to link resourse inside ( linked to first selection)
For this i change file collection.grid.resource.js

I then modified GetList to leave the open button only for nested resources.
It makes no sense, in my opinion, to leave the button open for collections and selections.
In the first case insert into the collection is the same, in the second case, well, it's a selection.

I would have liked to add that, within a resource, reached with the **open button** it was NOT possible to create Collection and Selection but I was unable to