### PR TITLE
4.1.1 Change (Issue?): set icon for resources linked in selection

### DIFF
--- a/core/components/collections/src/Processors/Selection/GetList.php
+++ b/core/components/collections/src/Processors/Selection/GetList.php
@@ -590,6 +590,7 @@ class GetList extends GetListProcessor
         $resourceArray = $this->prepareSupportFields($resourceArray);
         $resourceArray = $this->prepareActions($resourceArray);
         $resourceArray = $this->prepareMenuActions($resourceArray);
+        $resourceArray['icons'] = 'icon icon-chain';
 
         return $resourceArray;
     }


### PR DESCRIPTION
Now the resource linked in selection don't have icon near pagetitle, (render contain icon), because this is not set in getlist

I set this in icon-chain