### PR TITLE
4.1.1 Change: SUB COLLECTION, show if nested and set icon

### DIFF
--- a/core/components/collections/lexicon/en/default.inc.php
+++ b/core/components/collections/lexicon/en/default.inc.php
@@ -31,6 +31,8 @@ $_lang['setting_collections.tree_tbar_collection'] = 'Tree Tool Bar - Collection
 $_lang['setting_collections.tree_tbar_collection_desc'] = 'Show "New Collection" button in Tree tool bar';
 $_lang['setting_collections.tree_tbar_selection'] = 'Tree Tool Bar - Selection';
 $_lang['setting_collections.tree_tbar_selection_desc'] = 'Show "New Selection" button in Tree tool bar';
+$_lang['setting_collections.mostra_sub_collections'] = 'Show Nested Collection/Selection';
+$_lang['setting_collections.mostra_sub_collections_desc'] = 'Decidi if you wanto, or not, show nested Collection/Selection in grid';
 
 
 // System lexicons

--- a/core/components/collections/src/Processors/Resource/GetList.php
+++ b/core/components/collections/src/Processors/Resource/GetList.php
@@ -366,10 +366,13 @@ class GetList extends GetListProcessor
                 break;
         }
 
-        $c->where([
-            'class_key:!=' => CollectionContainer::class,
-//            "NOT EXISTS (SELECT 1 FROM {$this->modx->getTableName('modResource')} r WHERE r.parent = modResource.id)"
-        ]);
+        
+        if (!$this->modx->getOption('mostra_sub_collections', null, false)) {
+                $c->where([
+                    'class_key:!=' => CollectionContainer::class,
+        //            "NOT EXISTS (SELECT 1 FROM {$this->modx->getTableName('modResource')} r WHERE r.parent = modResource.id)"
+                ]);
+		}
 
         foreach ($this->tvColumns as $column) {
             $c->leftJoin(modTemplateVarResource::class, '`TemplateVarResources_' . $column['column'] . '`', '`TemplateVarResources_' . $column['column'] . '`.`contentid` = modResource.id AND `TemplateVarResources_' . $column['column'] . '`.`tmplvarid` = ' . $column['id']);

--- a/core/components/collections/src/Processors/Resource/GetList.php
+++ b/core/components/collections/src/Processors/Resource/GetList.php
@@ -684,6 +684,13 @@ class GetList extends GetListProcessor
             $iconCls[] = 'parent-resource';
         }
 
+	if ($resourceArray['class_key'] == 'Collections\Model\SelectionContainer' ) {
+                $iconCls[] = 'selectioncontainer';
+        }
+        if ($resourceArray['class_key'] == 'Collections\Model\CollectionContainer' ) {
+                $iconCls[] = 'collectioncontainer';
+        }
+
         $resourceArray['icons'] = implode(' ', $iconCls);
 
         return $resourceArray;


### PR DESCRIPTION
With this change, nested collections can be made visible in the grid of other parent collection.
For these I set the icons that were not previously set
First I created the System Setting **mostra_sub_collections** and their lexicon.
If this is true collection nested show in grid.

After i set the icon for collection and selection not previously set