### PR TITLE
4.1.1 Change: SUB COLLECTION, hidden in tree

### DIFF
--- a/core/components/collections/lexicon/en/default.inc.php
+++ b/core/components/collections/lexicon/en/default.inc.php
@@ -31,6 +31,8 @@ $_lang['setting_collections.tree_tbar_collection'] = 'Tree Tool Bar - Collection
 $_lang['setting_collections.tree_tbar_collection_desc'] = 'Show "New Collection" button in Tree tool bar';
 $_lang['setting_collections.tree_tbar_selection'] = 'Tree Tool Bar - Selection';
 $_lang['setting_collections.tree_tbar_selection_desc'] = 'Show "New Selection" button in Tree tool bar';
+$_lang['setting_collections.mostra_sub_collections_tree'] = 'Show Nested Collection/Selection in Tree';
+$_lang['setting_collections.mostra_sub_collections_tree_desc'] = 'Decide if you want, or not, show nested Collection/Selection in resorce's tree';
 
 
 // System lexicons

--- a/core/components/collections/src/Events/OnBeforeDocFormSave.php
+++ b/core/components/collections/src/Events/OnBeforeDocFormSave.php
@@ -22,7 +22,12 @@ class OnBeforeDocFormSave extends Event
         }
 
         if ($resource->class_key == CollectionContainer::class) {
-            $resource->set('show_in_tree', 1);
+            if ($this->modx->getOption('mostra_sub_collections_tree', null, true)==false && $parent && ($parent->class_key == CollectionContainer::class))
+			{
+				$resource->set('show_in_tree', 0);
+			}else{
+				$resource->set('show_in_tree', 1);
+			}
         }
 
         /** @var modResource $original */
@@ -133,7 +138,12 @@ class OnBeforeDocFormSave extends Event
             $child->set('show_in_tree', 0);
 
             if ($child->class_key == CollectionContainer::class) {
-                $child->set('show_in_tree', 1);
+                if ($this->modx->getOption('mostra_sub_collections_tree', null, true)==false)
+				{
+					$resource->set('show_in_tree', 0);
+				}else{
+					$resource->set('show_in_tree', 1);
+				}
             }
 
             $child->save();

--- a/core/components/collections/src/Events/OnResourceBeforeSort.php
+++ b/core/components/collections/src/Events/OnResourceBeforeSort.php
@@ -36,7 +36,12 @@ class OnResourceBeforeSort extends Event
 //            }
 
             if ($resource->class_key == CollectionContainer::class) {
-                $resource->set('show_in_tree', 1);
+                if ($this->modx->getOption('mostra_sub_collections_tree', null, true)==false && $parent && ($parent->class_key == CollectionContainer::class))
+				{
+					$resource->set('show_in_tree', 0);
+				}else{
+					$resource->set('show_in_tree', 1);
+				}
             }
 
             $resource->save();


### PR DESCRIPTION
Now, nested collections are show in the tree.
With this change you can decide whether to hide them

First I created the System Setting mostra_sub_collections_tree and their lexicon.
If this is false, collection hide in tree.

I only changed some functions in 2 events, only those that, in my opinion, occurred in this setting (show/hide in tree).
The other functions don't intervene, it seems to me

The other processor/event that conteint show_in_tree are 
Events\OnBeforeEmptyTrash
Processors\Resource\ChangeChildParent.php
Processors\Resource\ChangeParent.php
They do not affect setting (i think :))