### PR TITLE
4.1.1 Change: SUB COLLECTION, refresh Tree

### DIFF
--- a/assets/components/collections/js/mgr/widgets/category/collections.grid.resources.js
+++ b/assets/components/collections/js/mgr/widgets/category/collections.grid.resources.js
@@ -541,7 +541,12 @@ Ext.extend(collections.grid.ContainerCollections,MODx.grid.Grid,{
                 ,id: this.menu.record.id
             }
             ,listeners: {
-                'success':{fn:this.refresh,scope:this}
+                'success':{fn:function(r) {
+                    this.refresh();
+					if(MODx.config.mostra_sub_collections_tree == true){
+						Ext.getCmp('modx-layout').refreshTrees();
+					}
+                },scope:this}
             }
         });
     }
@@ -556,7 +561,12 @@ Ext.extend(collections.grid.ContainerCollections,MODx.grid.Grid,{
                 ,id: this.menu.record.id
             }
             ,listeners: {
-                'success':{fn:this.refresh,scope:this}
+                'success':{fn:function(r) {
+                    this.refresh();
+					if(MODx.config.mostra_sub_collections_tree == true){
+						Ext.getCmp('modx-layout').refreshTrees();
+					}
+                },scope:this}
             }
         });
     }
@@ -577,6 +587,9 @@ Ext.extend(collections.grid.ContainerCollections,MODx.grid.Grid,{
                 'success': {fn:function(r) {
                     this.getSelectionModel().clearSelections(true);
                     this.refresh();
+                    if(MODx.config.mostra_sub_collections_tree == true){
+						Ext.getCmp('modx-layout').refreshTrees();
+					}
                 },scope:this}
             }
         });
@@ -597,6 +610,9 @@ Ext.extend(collections.grid.ContainerCollections,MODx.grid.Grid,{
                 'success': {fn:function(r) {
                     this.getSelectionModel().clearSelections(true);
                     this.refresh();
+                    if(MODx.config.mostra_sub_collections_tree == true){
+						Ext.getCmp('modx-layout').refreshTrees();
+					}
                 },scope:this}
             }
         });
@@ -630,6 +646,9 @@ Ext.extend(collections.grid.ContainerCollections,MODx.grid.Grid,{
                 'success': {fn:function(r) {
                     this.getSelectionModel().clearSelections(true);
                     this.refresh();
+                    if(MODx.config.mostra_sub_collections_tree == true){
+						Ext.getCmp('modx-layout').refreshTrees();
+					}
                 },scope:this}
             }
         });
@@ -650,6 +669,9 @@ Ext.extend(collections.grid.ContainerCollections,MODx.grid.Grid,{
                 'success': {fn:function(r) {
                     this.getSelectionModel().clearSelections(true);
                     this.refresh();
+                    if(MODx.config.mostra_sub_collections_tree == true){
+						Ext.getCmp('modx-layout').refreshTrees();
+					}
                 },scope:this}
             }
         });
@@ -664,7 +686,12 @@ Ext.extend(collections.grid.ContainerCollections,MODx.grid.Grid,{
                 ,id: this.menu.record.id
             }
             ,listeners: {
-                'success':{fn:this.refresh,scope:this}
+                'success':{fn:function(r) {
+                    this.refresh();
+					if(MODx.config.mostra_sub_collections_tree == true){
+						Ext.getCmp('modx-layout').refreshTrees();
+					}
+                },scope:this}
             }
         });
     }
@@ -677,7 +704,12 @@ Ext.extend(collections.grid.ContainerCollections,MODx.grid.Grid,{
                 ,id: this.menu.record.id
             }
             ,listeners: {
-                'success':{fn:this.refresh,scope:this}
+                'success':{fn:function(r) {
+                    this.refresh();
+					if(MODx.config.mostra_sub_collections_tree == true){
+						Ext.getCmp('modx-layout').refreshTrees();
+					}
+                },scope:this}
             }
         });
     }


### PR DESCRIPTION
Refresh Tree when needed

If mostra_sub_collections and mostra_sub_collections_tree the nested collection show in grid and in resource's tree.
When I change the status (e.g. ppublis/unpublish) in the grid, it must also change in the tree to synchronize.
 
i introduce this only if mostra_sub_collections_tree is true and anly in follow function:
deleteChild
removeChild (non ho guardato cosa faccia)
deleteSelected
undeleteSelected
publishSelected
unpublishSelected
publishChild
unpublishChild

It shouldn't be useful for other functions