### PR TITLE
4.1.1 Customization: COLLECTIONs HEADER

### DIFF
--- a/assets/components/collections/js/mgr/widgets/category/collections.grid.resources.js
+++ b/assets/components/collections/js/mgr/widgets/category/collections.grid.resources.js
@@ -51,6 +51,11 @@ collections.grid.ContainerCollections = function(config) {
 
     window.history.replaceState({}, '', window.location.href);
 
+    if(MODx.config.mostra_cs_testata == true)
+	{
+		this.getTestataCollection(config);
+	}
+
     this.initBreadCrumbs(config);
 
     if (collections.template.allowDD) {
@@ -1177,7 +1182,50 @@ Ext.extend(collections.grid.ContainerCollections,MODx.grid.Grid,{
         });
         this.getTopToolbar().add(this.bc);
     }
+    
+,getTestataCollection: function(config) {
+		
+		var collection = parseInt(MODx.request.id);
 
+		MODx.Ajax.request({
+                    url: MODx.config.connector_url
+                    ,params: {
+                        action: 'Collections\\Processors\\Extra\\Testata'
+                        ,collection: collection
+                        ,selection: 0
+                    }
+                    ,listeners: {
+                        success: {
+                            fn: function(r) {
+                               this.printTestataCollection(r);
+                            },scope: this 
+                        },
+                        failure: {
+                            fn: function(){
+                                this.store.removeAll();
+                                this.currentFolder = collections.template.parent;
+                                this.getStore().baseParams.parent = collections.template.parent;
+                                this.getBottomToolbar().changePage(1);
+                            },
+                            scope: this
+                        }
+                    }
+                });
+				
+		
+	}
+    ,printTestataCollection: function(r) {
+	   this.testata = ({
+			items   : [{
+					html: '<div class="titoloTestataCS">'+r.results[1]+'</div>'+
+						  '<div class="menuTestataCS">'+r.results[0]+'</div>'
+					,bodyCssClass: 'contentTestataCS'
+					,anchor: '100%'
+				}]
+		});
+		this.getTopToolbar().insert(1,this.testata);
+    }
+    
     ,setPaginationState: function(start, limit) {
         var query = Ext.urlDecode(location.search.replace('?', ''));
         var folder = query.folder || collections.template.parent;

--- a/assets/components/collections/js/mgr/widgets/category/collections.grid.selection.js
+++ b/assets/components/collections/js/mgr/widgets/category/collections.grid.selection.js
@@ -331,7 +331,38 @@ Ext.extend(collections.grid.ContainerSelection,collections.grid.ContainerCollect
             }
         }
     }
-
+    
+    ,getTestataCollection: function(config) {
+    		
+    		var collection = parseInt(MODx.request.id);
+    
+    		MODx.Ajax.request({
+                        url: MODx.config.connector_url
+                        ,params: {
+                            action: 'Collections\\Processors\\Extra\\Testata'
+                            ,collection: collection
+                            ,selection: 1
+                        }
+                        ,listeners: {
+                            success: {
+                                fn: function(r) {
+                                   this.printTestataCollection(r);
+                                },scope: this 
+                            },
+                            failure: {
+                                fn: function(){
+                                    this.store.removeAll();
+                                    this.currentFolder = collections.template.parent;
+                                    this.getStore().baseParams.parent = collections.template.parent;
+                                    this.getBottomToolbar().changePage(1);
+                                },
+                                scope: this
+                            }
+                        }
+                    });
+    				
+    		
+    	}
     ,getDragDropText: function(){
         if (this.config.baseParams.sort != 'menuindex') {
             if (this.store.sortInfo == undefined || this.store.sortInfo.field != 'menuindex') {

--- a/core/components/collections/lexicon/en/default.inc.php
+++ b/core/components/collections/lexicon/en/default.inc.php
@@ -31,6 +31,8 @@ $_lang['setting_collections.tree_tbar_collection'] = 'Tree Tool Bar - Collection
 $_lang['setting_collections.tree_tbar_collection_desc'] = 'Show "New Collection" button in Tree tool bar';
 $_lang['setting_collections.tree_tbar_selection'] = 'Tree Tool Bar - Selection';
 $_lang['setting_collections.tree_tbar_selection_desc'] = 'Show "New Selection" button in Tree tool bar';
+$_lang['setting_collections.mostra_cs_testata'] = 'Show Header for Collection/Selection';
+$_lang['setting_collections.mostra_cs_testata_desc'] = 'Decide if you want to show Header for Collection/Selection';
 
 
 // System lexicons

--- a/core/components/collections/src/Processors/Extra/Testata.php
+++ b/core/components/collections/src/Processors/Extra/Testata.php
@@ -1,0 +1,64 @@
+<?php
+namespace Collections\Processors\Extra;
+
+use MODX\Revolution\modResource;
+use MODX\Revolution\Processors\Processor;
+
+class Testata extends Processor
+{
+    public function process()
+    {
+        $collection = (int)$this->getProperty('collection', 0);
+        $selection = (int)$this->getProperty('selection', 0);
+		
+		if ($collection <= 0) {
+            return $this->failure();
+        }
+		$resource = $this->modx->getObject(modResource::class, $collection);
+        if (!$resource) {
+            return $this->failure();
+        }
+				
+		//Discrimino a seconda che sia selezione oppure no per icona
+		$resource->published?$classPub ='pubblicata':$classPub ='ritirata';
+		if($selection)
+		{
+			$icona ='<i class="icon selectioncontainer"></i>';
+		}else{
+			$icona ='<i class="icon collectioncontainer"></i>';
+		}
+				
+		//Contesto 
+        $contextKey = $resource->context_key;
+		$context = $this->modx->getContext( $contextKey );
+		$contextName = $context->name;
+		
+		//Prima creo menu		
+		//Prima parte del menu il contesto con la sua icona
+		$menu = '<span class="eleMenu contesto"><i class="icon tree-context"></i>'.$contextName.'</span>';
+		
+		$pids = $this->modx->getParentIds($collection, 10, array('context' => $contextKey));
+		$gids = array_reverse($pids);
+		foreach($gids as $gid) 
+		{
+			if($gid == 0){continue;}
+				
+			$genit = $this->modx->getObject(modResource::class, $gid);
+			if (!$genit){continue;}
+			$genit->published?$classPubGen ='pubblicata':$classPubGen ='ritirata';
+			$genit->hidemenu?$classMenuGen ='nomenu':$classMenuGen ='simenu';
+			$menu .= '<span class="eleMenu '.$classPubGen.' '.$classMenuGen.'">'.$genit->pagetitle.'</span>';
+		}
+		//Ultimo elemento del menu la sua icona
+		$menu .= '<span class="ultimo '.$classPub.'">'.$icona.'</span>';
+		
+		$RisAjax [] = $menu;
+		
+		//Adesso nome a cui aggiungo icona
+		$nome = $icona;
+		$nome .= $resource->pagetitle;
+		$RisAjax [] = $nome;
+		
+		return $this->outputArray($RisAjax);
+    }
+}


### PR DESCRIPTION
In some of my projects some user groups can only see a collection and nothing else.
To make it more understandable I have introduced a header for each collection or selection with a small breadcrumb

I’m not an expert of extjs but this is my implementation. 

Opinions, errors and best solutions are welcome

Some images to understand better (with sub collection nested


![immagine](https://github.com/user-attachments/assets/cd44eaea-10c8-48c9-bc46-0274d84be639)
Second level collection, no in tree, with header with little crumbs


![immagine](https://github.com/user-attachments/assets/bcfe1eee-f434-459f-99a5-066d2e1f9e8a)
First Level collection


![immagine](https://github.com/user-attachments/assets/b62d3a79-35de-4de8-8cc9-14e7f5a20e23)
Collection with 2 resource opened


![immagine](https://github.com/user-attachments/assets/b9a3d0bb-462f-434c-839e-858fcf898962)
Slection 1 lev


![immagine](https://github.com/user-attachments/assets/6c39b88e-eaf6-4126-969a-4b4a49e4d936)
Selection 3 lev